### PR TITLE
Add support for AF_VSOCK

### DIFF
--- a/.github/workflows/publish_container_image.yml
+++ b/.github/workflows/publish_container_image.yml
@@ -34,6 +34,7 @@ jobs:
             latest=auto
           tags: |
             type=sha,format=long
+            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/systemd/echo@.service
+++ b/systemd/echo@.service
@@ -18,7 +18,6 @@ ExecStart=/usr/bin/podman run \
   --name echo-%i \
   --detach \
   --network none \
-  --userns=keep-id \
     ghcr.io/eriksjolund/socket-activate-echo
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id

--- a/systemd/echo@demo.socket.d/override.conf
+++ b/systemd/echo@demo.socket.d/override.conf
@@ -3,3 +3,7 @@ ListenStream=127.0.0.1:3000
 ListenDatagram=127.0.0.1:3000
 ListenStream=[::1]:3000
 ListenDatagram=[::1]:3000
+
+# VMADDR_CID_ANY (-1U) = 2^32 -1 = 4294967295
+# See "man vsock"
+ListenStream=vsock:4294967295:3000

--- a/vm/echo.butane
+++ b/vm/echo.butane
@@ -1,0 +1,92 @@
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+    - name: core
+
+systemd:
+  units:
+    - name: serial-getty@ttyS0.service
+      dropins:
+      - name: autologin-core.conf
+        contents: |
+          [Service]
+          ExecStart=
+          ExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM
+storage:
+  files:
+    - path: /var/lib/systemd/linger/core
+      mode: 0644
+    - path: /home/core/.config/systemd/user/echo@.service
+      user:
+        name: core
+      group:
+        name: core
+      mode: 0644
+      contents:
+        local: echo@.service
+    - path: /home/core/.config/systemd/user/echo@.socket
+      user:
+        name: core
+      group:
+        name: core
+      mode: 0644
+      contents:
+        local: echo@.socket
+    - path: /home/core/.config/systemd/user/echo@demo.socket.d/override.conf
+      user:
+        name: core
+      group:
+        name: core
+      mode: 0644
+      contents:
+        local: echo@demo.socket.d/override.conf
+    - path: /etc/sysctl.d/20-adjust-printk.conf
+      mode: 0644
+      contents:
+        inline: |
+          kernel.printk=4
+    - path: /etc/hostname
+      mode: 0644
+      contents:
+        inline: |
+          fcos
+  directories:
+    - path: /home/core/.config
+      mode: 0755
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/.config/systemd
+      mode: 0755
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/.config/systemd/user
+      mode: 0755
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/.config/systemd/user/default.target.wants
+      mode: 0755
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/.config/systemd/user/echo@demo.socket.d
+      mode: 0755
+      user:
+        name: core
+      group:
+        name: core
+  links:
+    - path: /home/core/.config/systemd/user/default.target.wants/echo@demo.socket
+      user:
+        name: core
+      group:
+        name: core
+      target: /home/core/.config/systemd/user/echo@.socket
+      hard: false


### PR DESCRIPTION
* Add AF_VSOCK listening socket for VMADDR_CID_ANY

* Add butane file for installing Fedora CoreOS and the
  echo container

* Add notes about container-selinux version availability

* Remove "--userns keep-id". (Maybe add a section about
  improving security later instead)

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>