### PR TITLE
bump github action versions

### DIFF
--- a/.github/workflows/publish_container_image.yml
+++ b/.github/workflows/publish_container_image.yml
@@ -13,21 +13,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run docker/setup-qemu-action
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Run docker/setup-buildx-action
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: List available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Run docker/login-action
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run docker/metadata-action
         id: metadata_action_id
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/eriksjolund/socket-activate-echo
           flavor: |
@@ -44,10 +44,10 @@ jobs:
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
           file: ./Containerfile
-          platforms: linux/amd64,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
           tags: ${{ steps.metadata_action_id.outputs.tags }}
           labels: ${{ steps.metadata_action_id.outputs.labels }}


### PR DESCRIPTION
* bump github action versions

* remove architecture linux/riscv64 because that architecture is no longer available at Dockerhub for docker.io/library/ubuntu:22.04

